### PR TITLE
Update formula for veracode-cli version 2.31.0

### DIFF
--- a/Formula/veracode-cli.rb
+++ b/Formula/veracode-cli.rb
@@ -1,19 +1,19 @@
 class VeracodeCli < Formula
   desc "Command-line tool for testing application security with Veracode"
   homepage "https://www.veracode.com"
-  version "2.30.1"
+  version "2.31.0"
   license "MIT"
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.30.1_macosx_arm64.tar.gz"
-      sha256 "f9dd3d15dbdc92ff3307a50d17d51ef8dbc4e5ed0713e05d530754fb80da870d"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.31.0_macosx_arm64.tar.gz"
+      sha256 "f8fdec76b9c2a90d91dd5d38a4f8a3c5ded9154a4b5ec3343ff7036b0da2b61e"
     elsif Hardware::CPU.intel?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.30.1_macosx_x86.tar.gz"
-      sha256 "b829a49d6fa3793bb29598ce85b2944f0a8395ef9de6887e7231245b282169cc"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.31.0_macosx_x86.tar.gz"
+      sha256 "5825d189e0a18feb80c9e464fccd24e28fc48862bfd7e1914a30f1c5e21274b4"
     end
   elsif OS.linux?
-    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.30.1_linux_x86.tar.gz"
-    sha256 "81edbad3cf97c7cc0d1750872e0c33e56446b042b0b664e91ac95f94771ecb7e"
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.31.0_linux_x86.tar.gz"
+    sha256 "0ff2b5f90e56c8b383536e9b6aa3015e256b8bb47a7d04b2b4d4a2ecbbbcedc5"
   end
   def install
     bin.install "veracode"


### PR DESCRIPTION
This PR updates the brew formula to version 2.31.0