### PR TITLE
Update formula for veracode-cli version 2.32.0

### DIFF
--- a/Formula/veracode-cli.rb
+++ b/Formula/veracode-cli.rb
@@ -1,19 +1,19 @@
 class VeracodeCli < Formula
   desc "Command-line tool for testing application security with Veracode"
   homepage "https://www.veracode.com"
-  version "2.31.0"
+  version "2.32.0"
   license "MIT"
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.31.0_macosx_arm64.tar.gz"
-      sha256 "f8fdec76b9c2a90d91dd5d38a4f8a3c5ded9154a4b5ec3343ff7036b0da2b61e"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_macosx_arm64.tar.gz"
+      sha256 "8b30dac038b0013ef7e61897027d77dbaed89724655b463e0e3f7dda224e16a1"
     elsif Hardware::CPU.intel?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.31.0_macosx_x86.tar.gz"
-      sha256 "5825d189e0a18feb80c9e464fccd24e28fc48862bfd7e1914a30f1c5e21274b4"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_macosx_x86.tar.gz"
+      sha256 "916c914c0f2863ad11eeed1b5879246e040790f48e433abf45ff8752d7b1978a"
     end
   elsif OS.linux?
-    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.31.0_linux_x86.tar.gz"
-    sha256 "0ff2b5f90e56c8b383536e9b6aa3015e256b8bb47a7d04b2b4d4a2ecbbbcedc5"
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_linux_x86.tar.gz"
+    sha256 "3474576376ba4ef422656d4c23a634a1b30f5e596fca6e6fe6683811b468c934"
   end
   def install
     bin.install "veracode"


### PR DESCRIPTION
This PR updates the brew formula to version 2.32.0