### PR TITLE
Update formula for veracode-cli version 2.33.0

### DIFF
--- a/Formula/veracode-cli.rb
+++ b/Formula/veracode-cli.rb
@@ -1,19 +1,19 @@
 class VeracodeCli < Formula
   desc "Command-line tool for testing application security with Veracode"
   homepage "https://www.veracode.com"
-  version "2.32.0"
+  version "2.33.0"
   license "MIT"
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_macosx_arm64.tar.gz"
-      sha256 "8b30dac038b0013ef7e61897027d77dbaed89724655b463e0e3f7dda224e16a1"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.33.0_macosx_arm64.tar.gz"
+      sha256 "856515d53324f513bf9048332ab951eb2af00325bdd38fd81b53a14f65f3cf89"
     elsif Hardware::CPU.intel?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_macosx_x86.tar.gz"
-      sha256 "916c914c0f2863ad11eeed1b5879246e040790f48e433abf45ff8752d7b1978a"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.33.0_macosx_x86.tar.gz"
+      sha256 "dbaf85fcca1ac310622bb397a95a35f0c9f601dfdf4fbf26932efed28974db42"
     end
   elsif OS.linux?
-    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_linux_x86.tar.gz"
-    sha256 "3474576376ba4ef422656d4c23a634a1b30f5e596fca6e6fe6683811b468c934"
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.33.0_linux_x86.tar.gz"
+    sha256 "e77b8b4f3272865109735d2bf7bf29ca64e4e8780dcaa7f03106e9ad4459fa1c"
   end
   def install
     bin.install "veracode"

--- a/Formula/veracode-cli@2.32.0.rb
+++ b/Formula/veracode-cli@2.32.0.rb
@@ -1,0 +1,24 @@
+class VeracodeCLIAT2320 < Formula
+  desc "Command-line tool for testing application security with Veracode"
+  homepage "https://www.veracode.com"
+  version "2.32.0"
+  license "MIT"
+  if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_macosx_arm64.tar.gz"
+      sha256 "8b30dac038b0013ef7e61897027d77dbaed89724655b463e0e3f7dda224e16a1"
+    elsif Hardware::CPU.intel?
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_macosx_x86.tar.gz"
+      sha256 "916c914c0f2863ad11eeed1b5879246e040790f48e433abf45ff8752d7b1978a"
+    end
+  elsif OS.linux?
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.32.0_linux_x86.tar.gz"
+    sha256 "3474576376ba4ef422656d4c23a634a1b30f5e596fca6e6fe6683811b468c934"
+  end
+  def install
+    bin.install "veracode"
+  end
+  test do
+    system "#{bin}/veracode", "version"
+  end
+end


### PR DESCRIPTION
This PR updates the brew formula to version 2.33.0