### PR TITLE
Update formula for veracode-cli version 2.35.0

### DIFF
--- a/Formula/veracode-cli.rb
+++ b/Formula/veracode-cli.rb
@@ -1,19 +1,19 @@
 class VeracodeCli < Formula
   desc "Command-line tool for testing application security with Veracode"
   homepage "https://www.veracode.com"
-  version "2.34.0"
+  version "2.35.0"
   license "MIT"
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.34.0_macosx_arm64.tar.gz"
-      sha256 "14d914dad805dd10a4e41080c377173b1f8c3caa9133bc67d2c30dcc4ba0a68b"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.35.0_macosx_arm64.tar.gz"
+      sha256 "37641121f6f5043a1aa1314be18f14bf459b8adc4f3233977f25d25788b6a97f"
     elsif Hardware::CPU.intel?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.34.0_macosx_x86.tar.gz"
-      sha256 "a0cfa12f3c5feee20b5ccf41070a3155b5f9e8a7670ffe60cc7940901bb9afbe"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.35.0_macosx_x86.tar.gz"
+      sha256 "de68651f6757ac96627d25f1e94b27045767206981b3ba07cea3dcb76235729b"
     end
   elsif OS.linux?
-    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.34.0_linux_x86.tar.gz"
-    sha256 "28e7d313e9b9820af85e817ea8a4469650f23ac735aa60b58c64094c55a3db73"
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.35.0_linux_x86.tar.gz"
+    sha256 "c13b6a6bfea5c21269e0e057fe02cb55ad5b1a30efacf0ee95b9ea7e5a0761db"
   end
   def install
     bin.install "veracode"

--- a/Formula/veracode-cli@2.34.0.rb
+++ b/Formula/veracode-cli@2.34.0.rb
@@ -1,0 +1,24 @@
+class VeracodeCliAT2340 < Formula
+  desc "Command-line tool for testing application security with Veracode"
+  homepage "https://www.veracode.com"
+  version "2.34.0"
+  license "MIT"
+  if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.34.0_macosx_arm64.tar.gz"
+      sha256 "14d914dad805dd10a4e41080c377173b1f8c3caa9133bc67d2c30dcc4ba0a68b"
+    elsif Hardware::CPU.intel?
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.34.0_macosx_x86.tar.gz"
+      sha256 "a0cfa12f3c5feee20b5ccf41070a3155b5f9e8a7670ffe60cc7940901bb9afbe"
+    end
+  elsif OS.linux?
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.34.0_linux_x86.tar.gz"
+    sha256 "28e7d313e9b9820af85e817ea8a4469650f23ac735aa60b58c64094c55a3db73"
+  end
+  def install
+    bin.install "veracode"
+  end
+  test do
+    system "#{bin}/veracode", "version"
+  end
+end


### PR DESCRIPTION
This PR updates the brew formula to version 2.35.0