### PR TITLE
Fix scan_health formula to work on Intel

### DIFF
--- a/Formula/scan_health.rb
+++ b/Formula/scan_health.rb
@@ -22,7 +22,15 @@ class ScanHealth < Formula
   end
 
   def install
-    bin.install "scan_health*" => "scan_health"
+    if OS.mac?
+      if Hardware::CPU.arm?
+        bin.install "scan_health-mac-arm64" => "scan_health"
+      elsif Hardware::CPU.intel?
+        bin.install "scan_health-mac-amd64" => "scan_health"
+      end
+    elsif OS.linux?
+      bin.install "scan_health-linux-amd64" => "scan_health"
+    end
   end
 
   test do

--- a/Formula/scan_health.rb
+++ b/Formula/scan_health.rb
@@ -22,7 +22,7 @@ class ScanHealth < Formula
   end
 
   def install
-    bin.install "scan_health-mac-arm64" => "scan_health"
+    bin.install "scan_health*" => "scan_health"
   end
 
   test do

--- a/Formula/scan_health.rb
+++ b/Formula/scan_health.rb
@@ -26,6 +26,6 @@ class ScanHealth < Formula
   end
 
   test do
-    system "#{bin}/scan_health", "--help"
+    system bin/"scan_health", "--help"
   end
 end


### PR DESCRIPTION
An issue was reported with the scan_health formula where it would not install on Intel architectures.